### PR TITLE
fix: make search filter accent-insensitive

### DIFF
--- a/lib/assets/data/merchants.json
+++ b/lib/assets/data/merchants.json
@@ -401,7 +401,7 @@
   },
   {
     "id": "mcdonalds",
-    "displayName": "MacDonald's",
+    "displayName": "McDonald's",
     "formats": [
       "^\\d{10}$"
     ],

--- a/lib/src/home_page.dart
+++ b/lib/src/home_page.dart
@@ -1,3 +1,4 @@
+import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
@@ -129,13 +130,17 @@ class _HomePageState extends State<HomePage> {
                     } else if (state.status == Status.success) {
                       final cards = state.cards;
 
-                      // Filter cards based on search query if needed
+                      // Filter cards based on search query
+                      final queryNormalized = removeDiacritics(_searchQuery.toLowerCase());
+
                       final filteredCards = _searchQuery.isEmpty
                           ? cards
-                          : cards.where((card) =>
-                      card.name.toLowerCase().contains(_searchQuery) ||
-                          card.merchant.displayName.toLowerCase().contains(_searchQuery)
-                      ).toList();
+                          : cards.where((card) {
+                        final nameNormalized = removeDiacritics(card.name.toLowerCase());
+                        final merchantNameNormalized = removeDiacritics(card.merchant.displayName.toLowerCase());
+                        return nameNormalized.contains(queryNormalized) ||
+                            merchantNameNormalized.contains(queryNormalized);
+                      }).toList();
 
                       if (cards.isEmpty) {
                         return ListView(

--- a/lib/src/screens/add_card/select_merchant_screen.dart
+++ b/lib/src/screens/add_card/select_merchant_screen.dart
@@ -1,5 +1,6 @@
 import 'package:cartan/src/services/navigation_service.dart';
 import 'package:cartan/src/widgets/common/search_results.dart';
+import 'package:diacritic/diacritic.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cartan/src/repositories/merchants_repository.dart';
@@ -18,9 +19,6 @@ class SelectMerchantScreen extends StatefulWidget {
 class _SelectMerchantScreenState extends State<SelectMerchantScreen> {
   String _searchQuery = '';
 
-  void _startSearch() {
-    // Called when title is tapped. Search logic is already handled in SearchableAppBar
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -53,10 +51,15 @@ class _SelectMerchantScreenState extends State<SelectMerchantScreen> {
             merchants.sort((a, b) => a.displayName.toLowerCase().compareTo(b.displayName.toLowerCase()));
 
             // Filter merchants based on search query
-            final filteredMerchants =
-            _searchQuery.isEmpty
+            final queryNormalized = removeDiacritics(_searchQuery.toLowerCase());
+
+            final filteredMerchants = _searchQuery.isEmpty
                 ? merchants
-                : merchants.where((merchant) => merchant.displayName.toLowerCase().contains(_searchQuery)).toList();
+                : merchants.where((merchant) {
+              final nameNormalized = removeDiacritics(merchant.displayName.toLowerCase());
+              return nameNormalized.contains(queryNormalized);
+            }).toList();
+
 
             // Show message when no merchants match the search query
             if (filteredMerchants.isEmpty && _searchQuery.isNotEmpty) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -129,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  diacritic:
+    dependency: "direct main"
+    description:
+      name: diacritic
+      sha256: "12981945ec38931748836cd76f2b38773118d0baef3c68404bdfde9566147876"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.6"
   equatable:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   http: ^1.4.0
   flutter_launcher_icons: ^0.14.3
   webview_flutter: ^4.4.2
+  diacritic: ^0.1.6
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
filtering issue where user search queries were being matched strictly and failed to account for accented characters.

Example: Searching for farmacia would not match farmácia.

Introduced the diacritics package to normalize both the search query and the data being filtered.

Applied accent-insensitive filtering to:
- Merchant names
- Card names and their associated Merchant names

Closes #33 