### PR TITLE
fix: barcode/qr code fix for better scan read

### DIFF
--- a/lib/src/screens/card-details/fullscreen_code_page.dart
+++ b/lib/src/screens/card-details/fullscreen_code_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:barcode_widget/barcode_widget.dart';
 import 'package:cartan/utils/system_brightness.dart';
@@ -25,11 +26,25 @@ class _FullScreenCodePageState extends State<FullScreenCodePage> {
   void initState() {
     super.initState();
     _setMaxBrightness();
+
+    // Portrait only
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+    ]);
   }
 
   @override
   void dispose() {
     _restoreBrightness();
+
+    // Restores all orientations
+    SystemChrome.setPreferredOrientations([
+      DeviceOrientation.portraitUp,
+      DeviceOrientation.portraitDown,
+      DeviceOrientation.landscapeLeft,
+      DeviceOrientation.landscapeRight,
+    ]);
+
     super.dispose();
   }
 
@@ -45,6 +60,22 @@ class _FullScreenCodePageState extends State<FullScreenCodePage> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final screenSize = MediaQuery.of(context).size;
+    final screenHeight = screenSize.height;
+    final screenWidth = screenSize.width;
+
+    const double paddingAll = 16.0;
+
+    final double containerWidth = widget.showQrCode
+        ? screenWidth * 0.85
+        : screenWidth * 0.6;
+
+    final double containerHeight = widget.showQrCode
+        ? screenWidth * 0.85
+        : screenHeight * 0.8;
+
+    final double innerWidth = containerWidth - paddingAll * 2;
+    final double innerHeight = containerHeight - paddingAll * 2;
 
     return Scaffold(
       backgroundColor: theme.colorScheme.surface,
@@ -61,26 +92,49 @@ class _FullScreenCodePageState extends State<FullScreenCodePage> {
         ),
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            if (widget.showQrCode)
-              QrImageView(
-                data: widget.cardNumber,
-                version: QrVersions.auto,
-                size: 300,
-                backgroundColor: Colors.white,
-              )
-            else
-              BarcodeWidget(
+        child: Container(
+          width: containerWidth,
+          height: containerHeight,
+          padding: const EdgeInsets.all(paddingAll),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.1),
+                blurRadius: 10,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: widget.showQrCode
+          // QR Code
+              ? Center(
+            child: QrImageView(
+              data: widget.cardNumber,
+              version: QrVersions.auto,
+              size: innerWidth.clamp(200.0, 400.0),
+              backgroundColor: Colors.white,
+              padding: EdgeInsets.zero,
+            ),
+          )
+          // Barcode
+              : RotatedBox(
+            quarterTurns: 1,
+            child: SizedBox(
+              width: innerHeight,
+              height: innerWidth,
+              child: BarcodeWidget(
                 barcode: Barcode.code128(),
                 data: widget.cardNumber,
-                width: 300,
-                height: 150,
+                width: innerHeight,
+                height: innerWidth,
                 drawText: false,
-                color: theme.colorScheme.primary,
+                color: Colors.black,
+                backgroundColor: Colors.white,
               ),
-          ],
+            ),
+          ),
         ),
       ),
     );

--- a/lib/src/widgets/card_details/code_display.dart
+++ b/lib/src/widgets/card_details/code_display.dart
@@ -28,7 +28,6 @@ class CodeDisplayWidget extends StatelessWidget {
     late final double barcodeHeight;
     late final double verticalSpacing;
     late final double containerPadding;
-    late final EdgeInsets qrPadding;
 
     if (isLandscape) {
       qrSize = 120.0;
@@ -36,17 +35,12 @@ class CodeDisplayWidget extends StatelessWidget {
       barcodeHeight = 80.0;
       verticalSpacing = 8.0;
       containerPadding = 12.0;
-      qrPadding = EdgeInsets.all(containerPadding);
     } else {
       qrSize = 200.0;
       barcodeWidth = 300.0;
       barcodeHeight = 120.0;
       verticalSpacing = 24.0;
       containerPadding = 14.0;
-      qrPadding = EdgeInsets.symmetric(
-        horizontal: containerPadding,
-        vertical: containerPadding,
-      );
     }
 
     return Container(
@@ -64,20 +58,17 @@ class CodeDisplayWidget extends StatelessWidget {
                   onTap: onZoomPressed,
                   borderRadius: BorderRadius.circular(8),
                   child: Container(
-                    width: qrSize,
-                    height: qrSize,
-                    padding: qrPadding,
-                    color: Colors.white,
-                    alignment: Alignment.center,
-                    child: FittedBox(
-                      fit: BoxFit.contain,
-                      child: QrImageView(
-                        data: cardNumber,
-                        version: QrVersions.auto,
-                        size: qrSize,
-                        backgroundColor: Colors.white,
-                        padding: EdgeInsets.zero,
-                      ),
+                    padding: EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: QrImageView(
+                      data: cardNumber,
+                      version: QrVersions.auto,
+                      size: qrSize,
+                      backgroundColor: Colors.white,
+                      padding: EdgeInsets.all(8),
                     ),
                   ),
                 ),
@@ -88,14 +79,18 @@ class CodeDisplayWidget extends StatelessWidget {
                   onTap: onZoomPressed,
                   borderRadius: BorderRadius.circular(8),
                   child: Container(
-                    padding: EdgeInsets.all(16),
+                    padding: EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
                     child: BarcodeWidget(
                       barcode: Barcode.code128(),
                       data: cardNumber,
                       width: barcodeWidth,
                       height: barcodeHeight,
                       drawText: false,
-                      color: theme.colorScheme.primary,
+                      color: Colors.black,
                     ),
                   ),
                 ),


### PR DESCRIPTION
Improvements to the barcode and QR code rendering:

- Added a white container behind the barcode/QR code to enhance contrast and improve scanning reliability across devices.
- Improved the zoom view for barcodes, making them more readable and easier to scan in full-screen mode.

![Screenshot_2025-06-05-18-07-22-524_com cogniwave cartan dev](https://github.com/user-attachments/assets/9e472f63-74b8-451b-9b1c-6adbcaf15c70)
![Screenshot_2025-06-05-18-07-28-301_com cogniwave cartan dev](https://github.com/user-attachments/assets/b398e625-cfd7-4651-b419-63619c15f928)
![Screenshot_2025-06-05-18-07-36-127_com cogniwave cartan dev](https://github.com/user-attachments/assets/afd47a76-196f-4b2b-a1ed-3434e610d5ec)
![Screenshot_2025-06-05-18-07-42-912_com cogniwave cartan dev](https://github.com/user-attachments/assets/fbd01cae-9e40-4dbe-9489-136285c8d898)
![Screenshot_2025-06-05-18-08-04-202_com cogniwave cartan dev](https://github.com/user-attachments/assets/0c500c66-900d-45a5-bb8e-c7fe4a050349)

Closes #40 